### PR TITLE
fix #49

### DIFF
--- a/adsbcot/classes.py
+++ b/adsbcot/classes.py
@@ -137,7 +137,7 @@ class ADSBWorker(pytak.QueueWorker):
                 self._logger.error(response_content)
                 return
 
-            json_resp = await resp.json()
+            json_resp = await resp.json(content_type=None)
             if json_resp is None:
                 return
 
@@ -460,7 +460,7 @@ class FileWatcher(pytak.QueueWorker):
                 self._logger.error(response_content)
                 return
 
-            json_resp = await resp.json()
+            json_resp = await resp.json(content_type=None)
             if json_resp is None:
                 return
 


### PR DESCRIPTION
Fixes issue #49 by adding `content_type=None` to the `json_resp = await resp.json()` lines.
This resolves the error and allows `adsbcot` to retrieve ADS-B aircraft messages as intended.